### PR TITLE
Do not add search option if no fulltext search is available

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
@@ -258,4 +258,4 @@ page {
 
   }
 
-[global]
+[END]

--- a/Resources/Private/Partials/KitodoPageView.html
+++ b/Resources/Private/Partials/KitodoPageView.html
@@ -67,9 +67,6 @@
                         <f:then>
                           <f:cObject typoscriptObjectPath="plugin.tx_dlf_searchindocumenttool" />
                         </f:then>
-                        <f:else>
-                          <f:cObject typoscriptObjectPath="lib.kitodo.fulltext.search" />
-                        </f:else>
                       </f:if>
                     </div>
                     <div id="tx-dlf-fulltextselection"></div>

--- a/Resources/Private/Plugins/Kitodo/Pageview.html
+++ b/Resources/Private/Plugins/Kitodo/Pageview.html
@@ -1,4 +1,3 @@
 <!-- ###TEMPLATE### -->
 <div id="tx-dlf-map" class="tx-dlf-map"></div>
-<div style="display:none;">###VIEWER_JS###</div><!-- only necessary in Kitodo.Presentation 2.x-->
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
Search in fulltext with the search plugin does not make sense, if we have no fulltext to search in.

This may be interessting to search in metadata. But do we want this?