### PR TITLE
Add the Kitodo.Presentation fulltext download tool (TXT format)

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/setup9.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/setup9.typoscript
@@ -242,6 +242,11 @@ plugin.tx_dlf_imagemanipulationtool {
     templateFile = {$config.kitodo.templates.toolsImageManipulation}
 }
 
+plugin.tx_dlf_fulltextdownloadtool {
+    pages = {$config.kitodo.storagePid}
+    templateFile = {$config.kitodo.templates.toolFulltextdownload}
+}
+
 # --------------------------------------------------------------------------------------------------------------------
 # newspaper navigation
 # --------------------------------------------------------------------------------------------------------------------

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -119,6 +119,9 @@ config {
             # cat=plugin.tx_slubdigitalcollections/advanced/0416; type=string; label=ToolsImagemanipulation Template
             toolsImageManipulation = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/ToolsImagemanipulation.html
 
+            # cat=plugin.tx_slubdigitalcollections/advanced/0415; type=string; label=ToolFullText Template
+            toolFulltextdownload = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/FulltextDownloadTool.html
+
             # cat=plugin.tx_slubdigitalcollections/advanced/0417; type=string; label=NewspaperYear Template
             newspaperYear = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/NewspaperYear.html
 

--- a/Resources/Private/Partials/KitodoPageView.html
+++ b/Resources/Private/Partials/KitodoPageView.html
@@ -369,6 +369,10 @@
                                 <dc:extractFulltext file="{dc:xpath(xpath:'(//mets:fileSec/mets:fileGrp[@USE=\"FULLTEXT\"]//mets:file/mets:FLocat/@xlink:href)[{gp-page}]')}" />
                               </div>
                           </li>
+                          <f:comment><!-- [Fulltext downloads (TXT)] -------------------------- --></f:comment>
+                          <li class="txt-download">
+                            <f:cObject typoscriptObjectPath="plugin.tx_dlf_fulltextdownloadtool" />
+                          </li>
                       </f:else>
                   </f:if>
                 </f:if>

--- a/Resources/Private/Plugins/Kitodo/FulltextDownloadTool.html
+++ b/Resources/Private/Plugins/Kitodo/FulltextDownloadTool.html
@@ -1,0 +1,12 @@
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<!-- ###TEMPLATE### -->
+###FULLTEXT_DOWNLOAD###
+<!-- ###TEMPLATE### -->


### PR DESCRIPTION
Currently we only have a download for the XML file of the full text. But there is a Kitodo.Presentation tool to download the full text als pure text (rendered by JavaScript). This should be added - at least on single page view.