### PR TITLE
Update searchindocumenttool config for Kitodo.Presentation v3.3

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/setup9.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/setup9.typoscript
@@ -31,6 +31,12 @@ lib.kitodo.fulltext.search {
 # ajax search in workview
 # --------------------------------------------------------------------------------------------------------------------
 plugin.tx_dlf_searchindocumenttool {
+    idInputName = tx_dlf[id]
+    queryInputName = tx_dlf[query]
+    startInputName = tx_dlf[start]
+    pageInputName = tx_dlf[page]
+    highlightWordInputName = tx_dlf[highlight_word]
+    encryptedInputName = tx_dlf[encrypted]
     templateFile = {$config.kitodo.templates.searchInDocumentTool}
     pages = {$config.kitodo.storagePid}
     // UID of dlfCore0
@@ -234,6 +240,7 @@ plugin.tx_dlf_fulltexttool {
     templateFile = {$config.kitodo.templates.toolFullText}
     activateFullTextInitially = 0
     fullTextScrollElement = html, body
+    # TODO: Remove this once migration to v3.3 is completed
     searchHlParameters = tx_dlf[highlight_word]
 }
 


### PR DESCRIPTION
This PR adds some TypoScript configuration for `tx_dlf_searchindocumenttool` that is necessary in Kitodo.Presentation v3.3. Related to slub/slub_web_sachsendigital#4.

The variables are used to generate links to the search results in `getNeededQueryParams()` (`kitodo-presentation/SearchInDocument.js`). When the variables are not set, all links in the search result box just link back to the current page.

For reference: The values have been taken from `kitodo-presentation/Configuration/TypoScript/Toolbox/setup.txt`, the configuration has been introduced in commit kitodo/kitodo-presentation@414b62e9.