### PR TITLE
Add double localtermsofuse2 label

### DIFF
--- a/Resources/Private/Language/de.locallang_kitodo.xlf
+++ b/Resources/Private/Language/de.locallang_kitodo.xlf
@@ -57,6 +57,10 @@
 				<source><![CDATA[Local Terms of Use]]></source>
 				<target><![CDATA[Nutzungshinweis]]></target>
 			</trans-unit>
+			<trans-unit id="metadata.localtermsofuse2" approved="yes">
+				<source><![CDATA[Local Terms of Use]]></source>
+				<target><![CDATA[Nutzungshinweis]]></target>
+			</trans-unit>
 			<trans-unit id="metadata.opac_id" approved="yes">
 				<source><![CDATA[OPAC Identifier]]></source>
 				<target><![CDATA[OPAC-Identifier]]></target>

--- a/Resources/Private/Language/locallang_kitodo.xlf
+++ b/Resources/Private/Language/locallang_kitodo.xlf
@@ -363,6 +363,9 @@
 			<trans-unit id="metadata.localtermsofuse" xml:space="preserve">
 				<source>Local Terms of Use</source>
 			</trans-unit>
+			<trans-unit id="metadata.localtermsofuse2" xml:space="preserve">
+				<source>Local Terms of Use</source>
+			</trans-unit>
 			<trans-unit id="sortinfo" xml:space="preserve">
 				<source>Entries %s to %s from %s.</source>
 			</trans-unit>


### PR DESCRIPTION
The metadata record "terms of use" may be used twice to link each entry separately. Don't ask ;-)