### PR TITLE
Add transform parameter for calling findOneByParameters method

### DIFF
--- a/Classes/ViewHelpers/XpathViewHelper.php
+++ b/Classes/ViewHelpers/XpathViewHelper.php
@@ -95,6 +95,9 @@ class XpathViewHelper extends AbstractViewHelper
                 $parameters['id'] = $parametersDlf['id'];
             } else if (GeneralUtility::isValidUrl($parametersDlf['id'])) {
                 $parameters['location'] = $parametersDlf['id'];
+                if (isset($parametersDlf['transform'])) {
+                  $parameters['transform'] = $parametersDlf['transform'];
+                }
             }
         } else if (isset($parametersDlf['recordId'])) {
             $parameters['recordId'] = $parametersDlf['recordId'];


### PR DESCRIPTION
Transform parameter is needed if given document is not in METS format but should be transformed to METS.