### PR TITLE
Rename conditions for tool rendering to match Kitodo.Presentation

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<f:if condition="{annotationtool}">
+<f:if condition="{renderAnnotationTool}">
     <f:then>
         <li>
             <span class="tx-dlf-tools-annotations">
@@ -33,7 +33,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{imagemanipulationtool}">
+<f:if condition="{renderImageManipulationTool}">
     <f:then>
         <span>
             <span class="tx-dlf-tools-imagetools" id="tx-dlf-tools-imagetools"
@@ -44,7 +44,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{imagedownloadtool} && {imageDownload}">
+<f:if condition="{renderImageDownloadTool} && {imageDownload}">
     <f:then>
         <li>
             <span class="tx-dlf-tools-imagedownload">
@@ -74,7 +74,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{fulltexttool}">
+<f:if condition="{renderFulltextTool}">
     <f:then>
         <f:if condition="{fulltext}">
             <f:then>
@@ -92,7 +92,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{fulltextdownloadtool}">
+<f:if condition="{renderFulltextDownloadTool}">
     <f:then>
         <li>
             <f:if condition="{fulltextDownload}">
@@ -112,7 +112,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{pdfdownloadtool}">
+<f:if condition="{renderPdfDownloadTool}">
     <f:then>
         <f:if condition="{double} === 0">
             <f:then>
@@ -153,7 +153,7 @@
     </f:then>
 </f:if>
 
-<f:if condition="{searchindocumenttool} && {searchInDocument}">
+<f:if condition="{renderSearchInDocumentTool} && {searchInDocument}">
     <f:then>
         <f:if condition="{settings.searchUrl}">
             <f:then>


### PR DESCRIPTION
Depends on https://github.com/kitodo/kitodo-presentation/pull/941

Probably it should be optimized even further (e.g.removing window for misspelling).
Idea: The 'tool' setting should be removed and the name of the tool should be derived from the plugin name.

It is necessary for fixing issue https://github.com/kitodo/kitodo-presentation/issues/994