### PR TITLE
Fix call to`ExtensionUtility::configurePlugin`

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,14 +3,14 @@ defined('TYPO3_MODE') or die();
 
 // plugins
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-    'Slub.SlubDigitalcollections',
+    'SlubDigitalcollections',
     'SingleCollection',
     [
-        'SingleCollection' => 'show,search'
+        \Slub\SlubDigitalcollections\Controller\SingleCollectionController::class => 'show,search'
     ],
     // non-cacheable actions
     [
-        'SingleCollection' => 'search'
+        \Slub\SlubDigitalcollections\Controller\SingleCollectionController::class => 'search'
     ]
 );
 


### PR DESCRIPTION
Error:
`[NOTICE] request="7f793c25ff4d7" component="TYPO3.CMS.deprecations": Calling method TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin with argument $extensionName ("Slub.SlubDigitalcollections") containing the vendor name ("Slub") is deprecated and will stop working in TYPO3 11.0. - {"file":"/var/www/html/public/typo3/sysext/extbase/Classes/Utility/ExtensionUtility.php","line":171}`

Since TYPO3 10 `$extensionName` should be called only as 'SlubDigitalcollections'. This change is needed for upgrade to TYPO3 11, but it will not work with TYPO3 9.

Source: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html