### PR TITLE
Fix wrong page download icon

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
@@ -118,7 +118,7 @@
             <f:then>
                 <f:if condition="{pageLinks.0}">
                     <li>
-                        <f:link.external uri="{pageLinks.0}" class="download-document">
+                        <f:link.external uri="{pageLinks.0}" class="download-page">
                             <f:translate key="downloadSinglePage" /> (PDF)
                         </f:link.external>
                     </li>
@@ -127,14 +127,14 @@
             <f:else>
                 <f:if condition="{pageLinks.0}">
                     <li>
-                        <f:link.external uri="{pageLinks.0}" class="download-document">
+                        <f:link.external uri="{pageLinks.0}" class="download-page">
                             <f:translate key="downloadLeftPage" /> (PDF)
                         </f:link.external>
                     </li>
                 </f:if>
                 <f:if condition="{pageLinks.1}">
                     <li>
-                        <f:link.external uri="{pageLinks.1}" class="download-document">
+                        <f:link.external uri="{pageLinks.1}" class="download-page">
                             <f:translate key="downloadRightPage" /> (PDF)
                         </f:link.external>
                     </li>


### PR DESCRIPTION
Currently, the same icons are used for downloads of individual pages as well as entire publications, although there is actually a differentiation. This PR sets the correct class so the differentiation can take place.

![grafik](https://github.com/slub/slub_digitalcollections/assets/43964592/5f88fd4f-06be-4cff-82b3-7ccc7389fdf1)
