### PR TITLE
composer update in compatibility with typo3 v11.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   ],
   "license": "GPL-3.0-or-later",
   "require": {
-    "typo3/cms-core": "~9.5|^10.4",
-    "kitodo/presentation": "^4.0|dev-master"
+    "typo3/cms-core": "^10.4|^11.5",
+    "kitodo/presentation": "^4.1|dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '3.0.1',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '9.5.31-10.4.99',
+			'typo3' => '10.4.99-11.5.99',
 		),
 	),
 );


### PR DESCRIPTION
update composer for typo3 require max version ^11.5
necessary for seamless install of `slub/ddev-dfgviewer-dist`