### PR TITLE
Fix Deprecation: #88746 Path to `PageRepository`

### DIFF
--- a/Classes/ViewHelpers/PageInfoViewHelper.php
+++ b/Classes/ViewHelpers/PageInfoViewHelper.php
@@ -68,7 +68,7 @@ class PageInfoViewHelper extends AbstractViewHelper
         if (0 === $uid) {
             $pageUid = $GLOBALS['TSFE']->id;
         }
-        $pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
+        $pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Domain\Repository\PageRepository::class);
         $page = $pageRepository->getPage($pageUid);
 
         $output = $page[$field];


### PR DESCRIPTION
Change the path of `PageRepository` from `TYPO3\CMS\Frontend\Page\PageRepository` to `TYPO3\CMS\Core\Domain\Repository\PageRepository`.

See here: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-88746-PageRepositoryPHPClassMovedFromFrontendToCoreExtension.html

> In previous TYPO3 versions, accessing records was mixed between Frontend (handled by PageRepository) and Backend (handled by static methods in BackendUtility). In TYPO3 v9, the Context API was introduced and PageRepository now acts as a strong database accessor which is not bound to Frontend anymore, at all.
>
>In addition, various places of the backend also used PageRepository already, which violated the separation of packages, as TYPO3 Core aims to strictly separate Frontend and Backend application code.
>
>In the case of PageRepository, the code is used by both applications, and is therefore moved to Core system extension (EXT:core), and renamed to TYPO3\CMS\Core\Domain\Repository\PageRepository.
>
>Until TYPO3 v9, it was placed in TYPO3\CMS\Frontend\Page\PageRepository.

