### PR TITLE
Adjust PHPStan

### DIFF
--- a/.github/phpstan.neon
+++ b/.github/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findByIsListed\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findByIsSortable\(\)\.#'
             - '#Parameter \#1 \$uids of method Kitodo\\Dlf\\Domain\\Repository\\CollectionRepository::findAllByUids\(\) expects string, array\<int\> given\.#'
-            - '#Parameter \#1 \$collection of method Kitodo\\Dlf\\Domain\\Repository\\DocumentRepository::findSolrByCollection\(\) expects Kitodo\\Dlf\\Domain\\Model\\Collection\|TYPO3\\CMS\\Extbase\\Persistence\\Generic\\QueryResult, TYPO3\\CMS\\Extbase\\Persistence\\QueryResultInterface given\.#'
+            - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\DocumentRepository::findSolrByCollections\(\)\.#'
     level: 5
     paths:
         - ../Classes/


### PR DESCRIPTION
`DocumentRepository::findSolrByCollections` is available in Kitodo 4.1, but this repository still uses 4.0 - this is going to be changed soon

Should be merged before other PRs