### PR TITLE
Fix cache assignment in `ext_localconf.php for arrays

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,9 +16,8 @@ defined('TYPO3_MODE') or die();
 
 // cache configurations
 // Cache for Collection ViewHelper (Matomo statistics)
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_matomo_collections'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_matomo_collections'] = [];
-}
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_matomo_collections'] ??= [];
+
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_matomo_collections']['backend'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_matomo_collections']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
 }
@@ -27,9 +26,8 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 }
 
 // Cache for Collection Plugin
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_collections'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_collections'] = [];
-}
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_collections'] ??= [];
+
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_collections']['backend'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['slub_digitalcollections_collections']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
 }


### PR DESCRIPTION
Fix for errors:

```
Uncaught TYPO3 Exception #1476107295: PHP Warning: Undefined array key "slub_digitalcollections_matomo_collections" in /var/www/extensions/slub_digitalcollections/ext_localconf.php line 19
thrown in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php
in line 137
```

```
Uncaught TYPO3 Exception #1476107295: PHP Warning: Undefined array key "slub_digitalcollections_collections" in /var/www/extensions/slub_digitalcollections/ext_localconf.php line 30
thrown in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php
in line 137
```
