### PR TITLE
Fix calling registerPlugin with vendor name

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -2,7 +2,7 @@
 defined('TYPO3_MODE') or die();
 
 TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'Slub.SlubDigitalcollections',
+    'SlubDigitalcollections',
     'SingleCollection',
     'LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang.xlf:plugins.single_collection_view'
 );


### PR DESCRIPTION
The first parameter $extensionName of method \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin used to contain the vendor name in the past.
As the vendor name does not have any effect at all, it's usage has been marked as deprecated.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Deprecation-88995-CallingRegisterPluginWithVendorName.html