### PR TITLE
Fix typos in navigation template

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
@@ -191,7 +191,7 @@
                     </f:link.action>
                 </f:then>
                 <f:else>
-                    <span title="{f:translate(key: 'lastPage'}">
+                    <span title="{f:translate(key: 'lastPage')}">
                         <f:translate key="lastPage"/>
                     </span>
                 </f:else>
@@ -241,7 +241,7 @@
         <f:then>
             <div class="measureBacks" style="top: 100px;">
                 <span class="prev">
-                    <f:if condition="{currentMeasure} > 1}">
+                    <f:if condition="{currentMeasure} > 1">
                         <f:then>
                             <f:variable name="prevMeasure" value="{currentMeasure - 1}" />
                             <f:link.action addQueryString="1" additionalParams="{'tx_dlf[measure]':'{currentMeasure - 1}', 'tx_dlf[page]':'{measurePages.{prevMeasure}}'}">


### PR DESCRIPTION
Corrected typos in the HTML navigation template file `Main.html`:
1. Fixed a missing closing parenthesis in the Translation Key for lastPage.
2. Removed an closing brace in the if-condition check attribute for {currentMeasure} which was too much.