### PR TITLE
[BUGFIX] Children without links should be enclosed in `span` element with class `a`

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Plugins/Kitodo/Partials/TableOfContents/Children.html
@@ -36,7 +36,9 @@
 
     <f:if condition="{child.doNotLinkIt}">
         <f:then>
-            <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+            <span class="a">
+                <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+            </span>
         </f:then>
         <f:else>
             <f:link.action


### PR DESCRIPTION
It ensures correct indentation in TableOfContents plugin

The same change was made in https://github.com/kitodo/kitodo-presentation/pull/1292 as DFG Viewer depends on those both extensions.