### PR TITLE
[FEATURE] Add model download tool

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
@@ -74,6 +74,18 @@
     </f:then>
 </f:if>
 
+<f:if condition="{renderModelDownloadTool} && {modelDownload}">
+    <f:then>
+        <li>
+            <span class="tx-dlf-tools-modeldownload">
+                <f:link.external uri="{modelDownload.url}">
+                    <f:translate key="downloadModel" />
+                </f:link.external>
+            </span>
+        </li>
+    </f:then>
+</f:if>
+
 <f:if condition="{settings.tools} == 'scoretool'">
     <f:then>
         <f:if condition="{score}">


### PR DESCRIPTION
Currently, the model download tool exists in Kitodo.Presentation.

https://github.com/kitodo/kitodo-presentation/blob/f088772a644aa1af16a5b6d8fc57c6f621514430/Resources/Private/Templates/Toolbox/Main.html#L78-L88

In DFG-Viewer, the model download tool will not be displayed because the toolbox file of Digital Collections is used.

It's a bug in DFG-Viewer.

![image](https://github.com/user-attachments/assets/9c357b19-77b6-4067-8855-71849f749260)
