### PR TITLE
[BUGFIX] Fix display for pagination - 4.0

### DIFF
--- a/Resources/Private/Plugins/SingleCollection/Partials/Pagination.html
+++ b/Resources/Private/Plugins/SingleCollection/Partials/Pagination.html
@@ -6,7 +6,7 @@
                 <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': 1}" arguments="{searchParameter: lastSearch}" title="1">1</f:link.action>
             </li>
             <li class="previous">
-                <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'pagination.previous')}">{f:translate(key: 'prevPage')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'pagination.previous')}">{f:translate(key: 'listview.prevPage')}</f:link.action>
             </li>
         </f:then>
         <f:else>
@@ -14,7 +14,7 @@
                 <span>1</span>
             </li>
             <li class="previous disabled">
-                <span>{f:translate(key: 'prevPage')}</span>
+                <span>{f:translate(key: 'listview.prevPage')}</span>
             </li>
         </f:else>
     </f:if>
@@ -56,7 +56,7 @@
                 <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.lastPageNumberG}" arguments="{searchParameter: lastSearch}" title="{pagination.lastPageNumber}">{pagination.lastPageNumber}</f:link.action>
             </li>
             <li class="next">
-                <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'nextPage')}">{f:translate(key: 'nextPage')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'nextPage')}">{f:translate(key: 'listview.nextPage')}</f:link.action>
             </li>
         </f:then>
         <f:else>
@@ -64,7 +64,7 @@
                 <span>{pagination.lastPageNumber}</span>
             </li>
             <li class="next disabled">
-                <span>{f:translate(key: 'nextPage')}</span>
+                <span>{f:translate(key: 'listview.nextPage')}</span>
             </li>
         </f:else>
     </f:if>


### PR DESCRIPTION
Should be used signs `<` and `>` instead of long text which causes line to break

The same adjustment is made for original template in https://github.com/kitodo/kitodo-presentation/pull/1498