### PR TITLE
[BUGFIX] Restore displaying results to previous layout

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
+++ b/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
@@ -17,13 +17,8 @@
     <f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
     <ol class="tx-dlf-abstracts">
         <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
-        <f:variable name="docTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
+            <f:variable name="docTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
             <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
-            <f:link.page
-            pageUid="{settings.targetPidPageView}"
-            additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}"
-            class=""
-            title="{docTitle}">
                 <f:comment>
                     slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
                     The HTML comments make sure there is no whitespace in that case.
@@ -35,7 +30,7 @@
                 --></div>
                 <dl>
                     <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
-                    <dd class="tx-dlf-title">{docTitle}</dd>
+                    <dd class="tx-dlf-title"><f:link.page pageUid="{settings.targetPidPageView}" additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}" title="{docTitle}">{docTitle}</f:link.page></dd>
                     <f:if condition="{document.metadata}">
                         <f:for each="{listedMetadata}" as="metadata">
                             <f:if condition="{document.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
@@ -47,133 +42,130 @@
                         </f:for>
                         <f:if condition="{document.structure} == 'year'">
                             <dt class="tx-dlf-metadata-year"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.year' /></dt>
-                            <dd class="tx-dlf-metadata-year">{document.metsOrderlabel} </dd>
+                            <dd class="tx-dlf-metadata-year">{document.metsOrderlabel}</dd>
                         </f:if>
                     </f:if>
                     <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
-                    <dd class="tx-dlf-type">
-                        <f:translate key="LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{document.structure}" default="{document.structure}"/>
-                    </dd>
+                    <dd class="tx-dlf-type"><f:translate key="LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{document.structure}" default="{document.structure}"/></dd>
                 </dl>
-            </f:link.page>
 
-            <f:render partial="Basket/AddToBasket" arguments="{result: document}" />
+                <f:render partial="Basket/AddToBasket" arguments="{result: document}" />
 
-            <f:if condition="{document.children} || {document.searchResults}">
-                <button class="tx-dlf-morevolumes" title="{f:translate(key='listview.moredetails.toggle')}"><f:translate key='listview.moredetails.toggle' /></button>
-            </f:if>
-            <f:if condition="{document.children}">
-                <ol class="tx-dlf-volume">
-                    <f:for each="{document.children}" as="child" iteration="childIterator">
-                        <f:if condition="{document.structure} == 'ephemera' || {document.structure} == 'newspaper'">
-                        <f:then>
-                            <f:comment>Special output for Newspaper / Ephemera</f:comment>
-                            <li value="{childIterator.cycle}" class="years">
-                                <f:link.page
-                                pageUid="{settings.targetPidPageView}"
-                                additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
-                                class=""
-                                title="{f:if(condition:'{child.metsOrderlabel}', then:'{child.metsOrderlabel}', else:'[{document.title}]')}">
-                                {child.metsOrderlabel}
-                                </f:link.page>
-                            </li>
-                        </f:then>
-                        <f:else>
-                            <li value="{childIterator.cycle}" class="pageresult">
-                                <f:link.page
-                                pageUid="{settings.targetPidPageView}"
-                                additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
-                                class=""
-                                title="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}">
-                                    <div class="tx-dlf-listview-thumbnail"><!--
-                                    --><f:if condition="{child.thumbnail}">
-                                        <img src="{child.thumbnail}" loading="lazy" alt="Vorschaubild von {f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
-                                    </f:if><!--
-                                    --></div>
-                                    <dl>
-                                    <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
-                                    <dd class="tx-dlf-title">{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}</dd>
-                                    <f:for each="{listedMetadata}" as="metadata">
-                                        <f:if condition="{child.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
-                                            <dt class="tx-dlf-metadata-{metadata.indexName}">
-                                                {metadata.label}
-                                            </dt>
-                                            <f:for each="{child.metadata.{metadata.indexName}}" as="metadataentry">
-                                                <dd class="tx-dlf-metadata-{metadata.indexName}">
-                                                        {metadataentry}
-                                                </dd>
-                                            </f:for>
-                                        </f:if>
-                                    </f:for>
-                                    <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
-                                    <dd class="tx-dlf-type">
-                                        <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.structure}' />
-                                    </dd>
-                                    </dl>
-                                </f:link.page>
-
-                                <f:render partial="Basket/AddToBasket" arguments="{result: child}" />
-
-                            </li>
-                        </f:else>
-                        </f:if>
-                    </f:for>
-                </ol>
-            </f:if>
-
-            <f:if condition="{document.searchResults}">
-                <ol class="tx-dlf-volume">
-                    <f:for each="{document.searchResults}" as="result" iteration="resultIterator">
-                        <li value="{resultIterator.cycle}" class="pageresult">
-                            <f:link.page
-                                pageUid="{settings.targetPidPageView}"
-                                additionalParams="{tx_dlf:{page:'{result.page}', double:'0', id:'{document.uid}', pagegrid:'0', highlight_word: '{result.highlight_word}'}}"
-                                class=""
-                                title="{f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}, Seite {result.page}">
-                                <div class="tx-dlf-listview-thumbnail"><!--
-                                    --><f:if condition="{result.thumbnail}">
-                                        <img src="{result.thumbnail}" loading="lazy" alt="Vorschaubild von {f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}" />
-                                    </f:if><!--
-                                --></div>
-                                <dl>
-                                    <f:if condition="{result.title}">
-                                        <f:then>
-                                            <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
-                                            <dd class="tx-dlf-title">{result.title}</dd>
-                                        </f:then>
-                                    </f:if>
-                                    <f:if condition="{result.structure} != 'page'">
+                <f:if condition="{document.children} || {document.searchResults}">
+                    <button class="tx-dlf-morevolumes" title="{f:translate(key='listview.moredetails.toggle')}"><f:translate key='listview.moredetails.toggle' /></button>
+                </f:if>
+                <f:if condition="{document.children}">
+                    <ol class="tx-dlf-volume">
+                        <f:for each="{document.children}" as="child" iteration="childIterator">
+                            <f:if condition="{document.structure} == 'ephemera' || {document.structure} == 'newspaper'">
+                            <f:then>
+                                <f:comment>Special output for Newspaper / Ephemera</f:comment>
+                                <li value="{childIterator.cycle}" class="years">
+                                    <f:link.page
+                                    pageUid="{settings.targetPidPageView}"
+                                    additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
+                                    class=""
+                                    title="{f:if(condition:'{child.metsOrderlabel}', then:'{child.metsOrderlabel}', else:'[{document.title}]')}">
+                                    {child.metsOrderlabel}
+                                    </f:link.page>
+                                </li>
+                            </f:then>
+                            <f:else>
+                                <li value="{childIterator.cycle}" class="pageresult">
+                                    <f:link.page
+                                    pageUid="{settings.targetPidPageView}"
+                                    additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
+                                    class=""
+                                    title="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}">
+                                        <div class="tx-dlf-listview-thumbnail"><!--
+                                        --><f:if condition="{child.thumbnail}">
+                                            <img src="{child.thumbnail}" loading="lazy" alt="Vorschaubild von {f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
+                                        </f:if><!--
+                                        --></div>
+                                        <dl>
+                                        <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
+                                        <dd class="tx-dlf-title">{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}</dd>
+                                        <f:for each="{listedMetadata}" as="metadata">
+                                            <f:if condition="{child.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
+                                                <dt class="tx-dlf-metadata-{metadata.indexName}">
+                                                    {metadata.label}
+                                                </dt>
+                                                <f:for each="{child.metadata.{metadata.indexName}}" as="metadataentry">
+                                                    <dd class="tx-dlf-metadata-{metadata.indexName}">
+                                                            {metadataentry}
+                                                    </dd>
+                                                </f:for>
+                                            </f:if>
+                                        </f:for>
                                         <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
                                         <dd class="tx-dlf-type">
-                                            <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{result.structure}' />
+                                            <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.structure}' />
                                         </dd>
-                                    </f:if>
-                                    <dt class="tx-dlf-page"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.page' /></dt>
-                                    <dd class="tx-dlf-page">{result.page}</dd>
-                                    <f:for each="{listedMetadata}" as="metadata">
-                                        <f:if condition="{result.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
-                                            <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
-                                            <f:for each="{result.metadata.{metadata.indexName}}" as="metadataentry">
-                                                <dd class="tx-dlf-metadata-{metadata.indexName}">
-                                                        {metadataentry}
-                                                </dd>
-                                            </f:for>
+                                        </dl>
+                                    </f:link.page>
+
+                                    <f:render partial="Basket/AddToBasket" arguments="{result: child}" />
+
+                                </li>
+                            </f:else>
+                            </f:if>
+                        </f:for>
+                    </ol>
+                </f:if>
+
+                <f:if condition="{document.searchResults}">
+                    <ol class="tx-dlf-volume">
+                        <f:for each="{document.searchResults}" as="result" iteration="resultIterator">
+                            <li value="{resultIterator.cycle}" class="pageresult">
+                                <f:link.page
+                                    pageUid="{settings.targetPidPageView}"
+                                    additionalParams="{tx_dlf:{page:'{result.page}', double:'0', id:'{document.uid}', pagegrid:'0', highlight_word: '{result.highlight_word}'}}"
+                                    class=""
+                                    title="{f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}, Seite {result.page}">
+                                    <div class="tx-dlf-listview-thumbnail"><!--
+                                        --><f:if condition="{result.thumbnail}">
+                                            <img src="{result.thumbnail}" loading="lazy" alt="Vorschaubild von {f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}" />
+                                        </f:if><!--
+                                    --></div>
+                                    <dl>
+                                        <f:if condition="{result.title}">
+                                            <f:then>
+                                                <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
+                                                <dd class="tx-dlf-title">{result.title}</dd>
+                                            </f:then>
                                         </f:if>
-                                    </f:for>
-                                </dl>
-                                <div class="tx-dlf-listview-preview">
-                                    <f:if condition="{result.snippet}">
-                                        <p class="textsnippet">[...] <f:format.raw>{result.snippet}</f:format.raw> [...]</p>
-                                    </f:if>
-                                </div>
-                            </f:link.page>
+                                        <f:if condition="{result.structure} != 'page'">
+                                            <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
+                                            <dd class="tx-dlf-type">
+                                                <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{result.structure}' />
+                                            </dd>
+                                        </f:if>
+                                        <dt class="tx-dlf-page"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.page' /></dt>
+                                        <dd class="tx-dlf-page">{result.page}</dd>
+                                        <f:for each="{listedMetadata}" as="metadata">
+                                            <f:if condition="{result.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
+                                                <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
+                                                <f:for each="{result.metadata.{metadata.indexName}}" as="metadataentry">
+                                                    <dd class="tx-dlf-metadata-{metadata.indexName}">
+                                                            {metadataentry}
+                                                    </dd>
+                                                </f:for>
+                                            </f:if>
+                                        </f:for>
+                                    </dl>
+                                    <div class="tx-dlf-listview-preview">
+                                        <f:if condition="{result.snippet}">
+                                            <p class="textsnippet">[...] <f:format.raw>{result.snippet}</f:format.raw> [...]</p>
+                                        </f:if>
+                                    </div>
+                                </f:link.page>
 
-                            <f:render partial="Basket/AddToBasket" arguments="{result: {uid:document.uid, page: result.page}}" />
+                                <f:render partial="Basket/AddToBasket" arguments="{result: {uid:document.uid, page: result.page}}" />
 
-                        </li>
-                    </f:for>
-                </ol>
-            </f:if>
+                            </li>
+                        </f:for>
+                    </ol>
+                </f:if>
             </li>
         </f:for>
     </ol>

--- a/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
+++ b/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
@@ -72,37 +72,26 @@
                             </f:then>
                             <f:else>
                                 <li value="{childIterator.cycle}" class="pageresult">
-                                    <f:link.page
-                                    pageUid="{settings.targetPidPageView}"
-                                    additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
-                                    class=""
-                                    title="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}">
-                                        <div class="tx-dlf-listview-thumbnail"><!--
+                                    <f:variable name="childTitle" value="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
+                                    <div class="tx-dlf-listview-thumbnail"><!--
                                         --><f:if condition="{child.thumbnail}">
-                                            <img src="{child.thumbnail}" loading="lazy" alt="Vorschaubild von {f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
+                                            <img src="{child.thumbnail}" loading="lazy" alt="Vorschaubild von {childTitle}" />
                                         </f:if><!--
-                                        --></div>
-                                        <dl>
+                                    --></div>
+                                    <dl>
                                         <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
-                                        <dd class="tx-dlf-title">{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}</dd>
+                                        <dd class="tx-dlf-title"><f:link.page pageUid="{settings.targetPidPageView}" additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}" title="{childTitle}">{childTitle}</f:link.page></dd>
                                         <f:for each="{listedMetadata}" as="metadata">
                                             <f:if condition="{child.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
-                                                <dt class="tx-dlf-metadata-{metadata.indexName}">
-                                                    {metadata.label}
-                                                </dt>
+                                                <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
                                                 <f:for each="{child.metadata.{metadata.indexName}}" as="metadataentry">
-                                                    <dd class="tx-dlf-metadata-{metadata.indexName}">
-                                                            {metadataentry}
-                                                    </dd>
+                                                    <dd class="tx-dlf-metadata-{metadata.indexName}">{metadataentry}</dd>
                                                 </f:for>
                                             </f:if>
                                         </f:for>
                                         <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
-                                        <dd class="tx-dlf-type">
-                                            <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.structure}' />
-                                        </dd>
-                                        </dl>
-                                    </f:link.page>
+                                        <dd class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.structure}' /></dd>
+                                    </dl>
 
                                     <f:render partial="Basket/AddToBasket" arguments="{result: child}" />
 

--- a/Resources/Private/Plugins/SingleCollection/Partials/Results.html
+++ b/Resources/Private/Plugins/SingleCollection/Partials/Results.html
@@ -59,29 +59,24 @@
                                 </f:then>
                                 <f:else>
                                     <li value="{childIterator.index}" class="pageresult">
-                                        <f:link.page pageUid="{settings.pageView}"
-                                            additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
-                                            class=""
-                                            title="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}">
-                                            <div class="tx-dlf-listview-thumbnail">
-                                                <f:if condition="{child.thumbnail}">
-                                                    <img src="{child.thumbnail}" loading="lazy"
-                                                        alt="Vorschaubild von {f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
+                                        <f:variable name="childTitle" value="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
+                                        <div class="tx-dlf-listview-thumbnail">
+                                            <f:if condition="{child.thumbnail}">
+                                                <img src="{child.thumbnail}" loading="lazy" alt="Vorschaubild von {childTitle}" />
+                                            </f:if>
+                                        </div>
+                                        <dl>
+                                            <dt class="tx-dlf-title"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.title' extensionName='slub_digitalcollections' /></dt>
+                                            <dd class="tx-dlf-title"><f:link.page pageUid="{settings.pageView}" additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}" title="{childTitle}">{childTitle}</f:link.page></dd>
+                                            <f:for each="{child.metadata}" as="metadata" key="label">
+                                                <f:if condition="{label} && {metadata.0} && {label} != 'type' && {label} != 'title'">
+                                                    <dt class="tx-dlf-{label}"><f:translate  key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.{label}' extensionName='slub_digitalcollections' /></dt>
+                                                    <dd>{metadata.0}</dd>
                                                 </f:if>
-                                            </div>
-                                            <dl>
-                                                <dt class="tx-dlf-title"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.title' extensionName='slub_digitalcollections' /></dt>
-                                                <dd class="tx-dlf-title">{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}</dd>
-                                                <f:for each="{child.metadata}" as="metadata" key="label">
-                                                    <f:if condition="{label} && {metadata.0} && {label} != 'type' && {label} != 'title'">
-                                                        <dt class="tx-dlf-{label}"><f:translate  key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.{label}' extensionName='slub_digitalcollections' /></dt>
-                                                        <dd>{metadata.0}</dd>
-                                                    </f:if>
-                                                </f:for>
-                                                <dt class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure' extensionName='slub_digitalcollections' /></dt>
-                                                <dd class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure.{child.structure}' extensionName='slub_digitalcollections' /></dd>
-                                            </dl>
-                                        </f:link.page>
+                                            </f:for>
+                                            <dt class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure' extensionName='slub_digitalcollections' /></dt>
+                                            <dd class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure.{child.structure}' extensionName='slub_digitalcollections' /></dd>
+                                        </dl>
                                     </li>
                                 </f:else>
                             </f:if>

--- a/Resources/Private/Plugins/SingleCollection/Partials/Results.html
+++ b/Resources/Private/Plugins/SingleCollection/Partials/Results.html
@@ -6,40 +6,37 @@
         <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
             <f:variable name="docTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
             <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
-                <f:link.page pageUid="{settings.pageView}"
-                    additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}"
-                    class="" title="{docTitle}">
-                    <f:comment>
-                        slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
-                        The HTML comments make sure there is no whitespace in that case.
-                    </f:comment>
-                    <div class="tx-dlf-listview-thumbnail">
-                        <f:if condition="{document.thumbnail}">
-                            <img src="{document.thumbnail}" loading="lazy" alt="Vorschaubild von {docTitle}" />
-                        </f:if>
-                    </div>
-                    <dl>
-                        <dt class="tx-dlf-title"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.title' extensionName='slub_digitalcollections' /></dt>
-                        <dd class="tx-dlf-title">{docTitle}</dd>
-                        <f:for each="{document.metadata}" as="metadata" key="label">
-                            <f:if condition="{label} && {metadata.0} && {label} != 'type' && {label} != 'title'">
-                                <dt class="tx-dlf-{label}"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.{label}' extensionName='slub_digitalcollections' />
-                                </dt>
-                                <f:if condition="{label} == 'year'">
-                                    <f:then>
-                                        <f:comment>Todo: ViewHelper to check given date string and format with f:format.date if possible</f:comment>
-                                        <dd>{metadata.0}</dd>
-                                    </f:then>
-                                    <f:else>
-                                        <dd>{metadata.0}</dd>
-                                    </f:else>
-                                </f:if>
+                <f:comment>
+                    slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
+                    The HTML comments make sure there is no whitespace in that case.
+                </f:comment>
+                <div class="tx-dlf-listview-thumbnail"><!--
+                    --><f:if condition="{document.thumbnail}">
+                        <img src="{document.thumbnail}" loading="lazy" alt="Vorschaubild von {docTitle}" />
+                    </f:if><!--
+                --></div>
+                <dl>
+                    <dt class="tx-dlf-title"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.title' extensionName='slub_digitalcollections' /></dt>
+                    <dd class="tx-dlf-title"><f:link.page pageUid="{settings.pageView}" additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}" title="{docTitle}">{docTitle}</f:link.page></dd>
+                    <f:for each="{document.metadata}" as="metadata" key="label">
+                        <f:if condition="{label} && {metadata.0} && {label} != 'type' && {label} != 'title'">
+                            <dt class="tx-dlf-{label}"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:metadata.{label}' extensionName='slub_digitalcollections' />
+                            </dt>
+                            <f:if condition="{label} == 'year'">
+                                <f:then>
+                                    <f:comment>Todo: ViewHelper to check given date string and format with f:format.date if possible</f:comment>
+                                    <dd>{metadata.0}</dd>
+                                </f:then>
+                                <f:else>
+                                    <dd>{metadata.0}</dd>
+                                </f:else>
                             </f:if>
-                        </f:for>
-                        <dt class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure' extensionName='slub_digitalcollections' /></dt>
-                            <dd class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure.{document.structure}' extensionName='slub_digitalcollections' /></dd>
-                    </dl>
-                </f:link.page>
+                        </f:if>
+                    </f:for>
+                    <dt class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure' extensionName='slub_digitalcollections' /></dt>
+                    <dd class="tx-dlf-type"><f:translate key='LLL:EXT:slub_digitalcollections/Resources/Private/Language/locallang_kitodo.xlf:structure.{document.structure}' extensionName='slub_digitalcollections' /></dd>
+                </dl>
+
                 <f:if condition="{document.children} || {document.searchResults}">
                     <button class="tx-dlf-morevolumes" title="{f:translate(key='listview.moredetails.toggle')}">
                         <f:translate key='listview.moredetails.toggle' />


### PR DESCRIPTION
Link should only be attached to title instead of the whole result element.