### PR TITLE
[BUGFIX] Fix template for displaying list of collections - 4.0

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Collection/List.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Collection/List.html
@@ -29,9 +29,7 @@
                     <h4>
                         <f:link.action action="show"
                                     arguments="{collection : item.collection}"
-                                    pageUid="{pageUid}">
-                            {item.collection.label}
-                        </f:link.action>
+                                    pageUid="{pageUid}">{item.collection.label}</f:link.action>
                     </h4>
 
                     <p class="tx-dlf-collection-counts">


### PR DESCRIPTION
If title of collection is not in the same line as the link tag than it adds empty space before and after title. The ordering doesn't work as it takes first character which in this case is white space.