### PR TITLE
Fix display of search results

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
+++ b/Resources/Private/Plugins/Kitodo/Partials/ListView/Results.html
@@ -18,7 +18,7 @@
     <ol class="tx-dlf-abstracts">
         <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
             <f:variable name="metadataTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
-            <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: 'LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:noTitle')}')}" />
+            <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: \'LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:noTitle\')}')}" />
             <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
             <f:link.page
             pageUid="{settings.targetPidPageView}"

--- a/Resources/Private/Plugins/SingleCollection/Partials/Results.html
+++ b/Resources/Private/Plugins/SingleCollection/Partials/Results.html
@@ -5,7 +5,7 @@
     <ol class="tx-dlf-abstracts">
         <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
             <f:variable name="metadataTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
-            <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: 'LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:noTitle')}')}" />
+            <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: \'LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:noTitle\')}')}" />
             <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
                 <f:link.page pageUid="{settings.pageView}"
                     additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}"


### PR DESCRIPTION
Several single quotes require escape characters.

Fixes: ed2c25180b53 ("Display [no title] for documents without title")