### PR TITLE
[BUGFIX] change the backend_layout check to use the traverse function

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
@@ -16,7 +16,7 @@ page {
     }
 }
 
-[page["backend_layout"] == 'pagets__kitodo' or page["backend_layout"] == 'pagets__emptyworkview']
+[traverse(page, 'backend_layout') == 'pagets__kitodo' or traverse(page, 'backend_layout') == 'pagets__emptyworkview']
     plugin.tx_slubdigitalcollections.disableWrapInBaseClass = 1
 
     # switch to viewer css
@@ -28,7 +28,7 @@ page {
     # clear not required js
     page.includeJSFooterlibs.kitodo-frontend >
 
-[global]
+[GLOBAL]
 
 # --------------------------------------------------------------------------------------------------------------------
 # add opengraph social metatags in single view with a valid id


### PR DESCRIPTION
fixing undefined "backend_layout" key Errors in several TYPO3 v12 BE Modules

see Screenshot:

![Screenshot 2025-05-09 at 14-09-14 TYPO3 Exception · musiconn-audio TYPO3 CMS 12 4 28](https://github.com/user-attachments/assets/0992acbf-0bd4-4cc4-97af-4fad72930c5a)
