### PR TITLE
[BUGFIX] - Add support for Typo3 v12 - check for request object first

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/common.typoscript
@@ -33,7 +33,7 @@ page {
 # --------------------------------------------------------------------------------------------------------------------
 # add opengraph social metatags in single view with a valid id
 # --------------------------------------------------------------------------------------------------------------------
-[traverse(request.getQueryParams(), 'tx_dlf/id') > 0]
+[request && traverse(request.getQueryParams(), 'tx_dlf/id') > 0]
 
   page.2 = LOAD_REGISTER
   page.2 {


### PR DESCRIPTION
FIX Error in TYPO3 v12 while Indexing: 

```
  [ RuntimeException ]                                             
  Unable to call method "getQueryParams" of non-object "request".
```