### PR TITLE
[BUGFIX] Fixes navigation URL encoding

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
@@ -25,16 +25,16 @@
             <f:if condition="{viewData.requestData.double}">
                 <f:then>
                     <div class="tx-dlf-navigation-double">
-                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'0'}"
-                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'0','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                             <f:translate key="doublePageOn"/>
                         </f:link.action>
                     </div>
                     <div class="tx-dlf-navigation-double+">
                         <f:if condition="{viewData.requestData.double} && ({viewData.requestData.page} < {numPages})">
                             <f:then>
-                                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}'}"
-                                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                                     <f:translate key="doublePage+1"/>
                                 </f:link.action>
                             </f:then>
@@ -47,8 +47,8 @@
                     </div>
                 </f:then>
                 <f:else>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'1'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'1','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="doublePageOn"/>
                     </f:link.action>
                 </f:else>
@@ -69,8 +69,8 @@
         <span class="first">
             <f:if condition="{viewData.requestData.page} > 1">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'1'}" class="first"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'1','tx_dlf[id]':'{viewData.partlyEncodedId}'}" class="first"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="firstPage"/>
                     </f:link.action>
                 </f:then>
@@ -87,8 +87,8 @@
     <span class="rwnd">
         <f:if condition="{viewData.requestData.page} > {pageSteps}">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
                 </f:link.action>
             </f:then>
@@ -105,8 +105,8 @@
         <span class="prev">
             <f:if condition="{viewData.requestData.page} > {viewData.requestData.double + 1}">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="prevPage"/>
                     </f:link.action>
                 </f:then>
@@ -145,12 +145,13 @@
 </f:section>
 
 <f:section name="render.pageForward">
+
     <div class="fwds">
         <span class="next">
             <f:if condition="{viewData.requestData.page + viewData.requestData.double} < {numPages}">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1 + viewData.requestData.double}'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1 + viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="nextPage"/>
                     </f:link.action>
                 </f:then>
@@ -167,8 +168,8 @@
         <span class="fwd">
             <f:if condition="{viewData.requestData.page} <= {numPages - pageSteps}">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
                     </f:link.action>
                 </f:then>
@@ -185,8 +186,8 @@
         <span class="last">
             <f:if condition="{viewData.requestData.page} < {numPages - viewData.requestData.double}">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="lastPage"/>
                     </f:link.action>
                 </f:then>
@@ -254,7 +255,8 @@
                     <f:if condition="{currentMeasure} > 1">
                         <f:then>
                             <f:variable name="prevMeasure" value="{currentMeasure - 1}" />
-                            <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'{currentMeasure - 1}', 'tx_dlf[page]':'{measurePages.{prevMeasure}}'}">
+                            <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'{currentMeasure - 1}', 'tx_dlf[page]':'{measurePages.{prevMeasure}}', 'tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                           argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[id]'}">
                                 <f:translate key="prevMeasure"/>
                             </f:link.action>
                         </f:then>
@@ -280,13 +282,14 @@
                             <f:if condition="{currentMeasure} > 0">
                                 <f:then>
                                     <f:variable name="nextMeasure" value="{currentMeasure + 1}" />
-                                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'{currentMeasure + 1}', 'tx_dlf[page]':'{measurePages.{nextMeasure}}'}">
+                                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'{currentMeasure + 1}', 'tx_dlf[page]':'{measurePages.{nextMeasure}}', 'tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[id]'}">
                                         <f:translate key="nextMeasure"/>
                                     </f:link.action>
                                 </f:then>
                                 <f:else>
-                                    <f:link.action
-                                            addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'1', 'tx_dlf[page]':'{measurePages.1}'}">
+                                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[measure]':'1', 'tx_dlf[page]':'{measurePages.1}', 'tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[id]'}">
                                         <f:translate key="nextMeasure"/>
                                     </f:link.action>
                                 </f:else>


### PR DESCRIPTION
- Implement workaround cause ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter 
  - For more details, please see the following TYPO3 issue https://forge.typo3.org/issues/107026