### PR TITLE
Fix PageInfoViewHelper to retrieve page UID from routing context

### DIFF
--- a/Classes/ViewHelpers/PageInfoViewHelper.php
+++ b/Classes/ViewHelpers/PageInfoViewHelper.php
@@ -23,6 +23,7 @@ namespace Slub\SlubDigitalcollections\ViewHelpers;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -66,8 +67,10 @@ class PageInfoViewHelper extends AbstractViewHelper
       ) {
         $pageUid = (int) $arguments['uid'];
         $field = $arguments['field'];
+
+        // If uid is 0, take the current page from routing context
         if ($pageUid === 0) {
-            /** @var RenderingContext $renderingContext */
+            /** @var \TYPO3\CMS\Fluid\Core\Rendering\RenderingContext $renderingContext */
             $request = $renderingContext->getRequest();
             $pageArguments = $request->getAttribute('routing');
             $pageUid = $pageArguments->getPageId();

--- a/Classes/ViewHelpers/PageInfoViewHelper.php
+++ b/Classes/ViewHelpers/PageInfoViewHelper.php
@@ -24,6 +24,7 @@ namespace Slub\SlubDigitalcollections\ViewHelpers;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -65,8 +66,11 @@ class PageInfoViewHelper extends AbstractViewHelper
       ) {
         $pageUid = (int) $arguments['uid'];
         $field = $arguments['field'];
-        if (0 === $pageUid) {
-            $pageUid = $GLOBALS['TSFE']->id;
+        if ($pageUid === 0) {
+            /** @var RenderingContext $renderingContext */
+            $request = $renderingContext->getRequest();
+            $pageArguments = $request->getAttribute('routing');
+            $pageUid = $pageArguments->getPageId();
         }
         $pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Domain\Repository\PageRepository::class);
         $page = $pageRepository->getPage($pageUid);


### PR DESCRIPTION
As access to `$GLOBALS['TSFE']` directly is [strongly discouraged](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/TSFE/Index.html#accessing-tsfe) and Deprecated since version 13.4, we switch to a modern approach.

See advice in TYPO3 reference coreapi documentation:
https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/TSFE/Index.html#tsfe-pageid

We get the PSR-7 request object, triaged by TYPO3 Version Check for >=11.3:
https://docs.typo3.org/permalink/t3coreapi:getting-typo3-request-object

PHPStan Error is Ignored, as written in the link above:
> In a ViewHelper you can get the rendering request from the rendering context. For this you have to rely on the fact that a \TYPO3\CMS\Fluid\Core\Rendering\RenderingContext is passed to the ViewHelpers renderStatic method, even though it is declared as RenderingContextInterface, which does not have the method.

For all Versions Prior to TYPO3 v11.3 the global variable is still used. 

TODO: Replace `TYPO3\CMS\Fluid\Core\Rendering\RenderingContext->getRequest()`
because of being [Deprecated since TYPO3 version 13.3](https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/RequestLifeCycle/Typo3Request.html#typo3-request-viewhelper)