### PR TITLE
Add multiViewType to `tx_dlf_pageview` in Kitodo config adapted from DFG-Viewer

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/setup.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/setup.typoscript
@@ -80,6 +80,7 @@ plugin.tx_dlf_pageview {
     settings {
         features =
         elementId = tx-dlf-map
+        multiViewType = composition
     }
 }
 


### PR DESCRIPTION
adapted from DFG-Viewer, see:
https://github.com/slub/dfg-viewer/commit/fad5720327489a714bb695ed700c09e1537bd752

Kitodo.Presentation throws an error if this configuration key in the settings is missing.
`PHP Warning: Undefined array key "multiViewType" in /var/www/html/packages/kitodo-presentation/Classes/Controller/PageViewController.php line 466`

@beatrycze-volk, should the check for a existing `multiViewType` Key should also be added to Kitodo?
Then we have to add the check here:
https://github.com/kitodo/kitodo-presentation/commit/fb1a41718815c916eeb40599a04b119e1b38265c
