### PR TITLE
add --no-audit flag to composer update in PHPStan workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Fix git ownership
+        run: git config --global --add safe.directory /app
+
       - name: Install dependencies
         uses: php-actions/composer@v6
         with:
           command: update
           php_version: ${{ matrix.variants.php }}
-          args: --ignore-platform-reqs --with=typo3/cms-core:^${{ matrix.variants.typo3 }}
+          args: --ignore-platform-reqs --no-audit --with=typo3/cms-core:^${{ matrix.variants.typo3 }}
 
       - name: PHPStan Static Analysis
         uses: php-actions/phpstan@v3

--- a/composer.json
+++ b/composer.json
@@ -65,12 +65,10 @@
     "allow-plugins": {
       "typo3/class-alias-loader": true,
       "typo3/cms-composer-installers": true
+    },
+    "audit": {
+        "block-insecure": false
     }
-  }
-  "policies": {
-      "advisories": {
-          "block": false
-      }
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,11 @@
       "typo3/class-alias-loader": true,
       "typo3/cms-composer-installers": true
     }
+  }
+  "policies": {
+      "advisories": {
+          "block": false
+      }
   },
   "repositories": [
     {


### PR DESCRIPTION
Security advisories for typo3/cms-core are not in scope for an extension repository. Disabling the audit.