### PR TITLE
[FEATURE] Add noHighlighting option for field display

### DIFF
--- a/Resources/Private/Plugins/Find/Partials/Display/Field/General.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Field/General.html
@@ -32,13 +32,23 @@
 				{groupItemPrefix->f:format.raw()}{fieldPrefix->f:format.raw()}
 					
 						<f:format.raw>
-							<s:find.highlightField
-								field="{field}"
-								document="{document}"
-								results="{results}"
-								index="{iterator.index}"
-								alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
-							/>
+
+							<f:if condition="{noHighlighting}">
+								<f:then>
+									{value}
+								</f:then>
+								<f:else>
+									<s:find.highlightField
+										field="{field}"
+										document="{document}"
+										results="{results}"
+										index="{iterator.index}"
+										alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
+									/>
+								</f:else>
+
+							</f:if>
+
 						</f:format.raw>
 
 				{fieldSuffix->f:format.raw()}{f:if(condition:"{iterator.isLast}==0", then:separator)}{groupItemSuffix->f:format.raw()}
@@ -51,13 +61,21 @@
 			</f:if>			
 			{fieldPrefix->f:format.raw()}
 				<f:format.raw>
-					<s:find.highlightField
-						field="{field}"
-						document="{document}"
-						results="{results}"
-						index="0"
-						alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
-					/>
+					<f:if condition="{noHighlighting}">
+						<f:then>
+							{document.fields.{field}}
+						</f:then>		
+						<f:else>
+							<s:find.highlightField
+								field="{field}"
+								document="{document}"
+								results="{results}"
+								index="0"
+								alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
+							/>
+
+						</f:else>
+					</f:if>			
 				</f:format.raw>
 			{fieldSuffix->f:format.raw()}
 		</f:else>

--- a/Resources/Private/Plugins/Find/Partials/Display/Field/Inline.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Field/Inline.html
@@ -26,6 +26,7 @@
 		separator:separator,
 		linkFieldContent:linkFieldContent,
 		linkFacets:linkFacets,
-		config:config
+		config:config,
+		noHighlighting: noHighlighting
 	}"
 />

--- a/Resources/Private/Plugins/Find/Partials/Display/Result.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Result.html
@@ -39,7 +39,8 @@
 							document:document,
 							field:settings.standardFields.title,
 							separator:', ',
-							prefixString: 'Titel'
+							prefixString: 'Titel',
+							noHighlighting: noHighlighting
 						}"/>
 				</f:then>
 				<f:else>
@@ -58,7 +59,8 @@
 								document:document,
 								field: stdFieldValue,
 								separator:', ',
-								prefixString: stdFieldKey
+								prefixString: stdFieldKey,
+								noHighlighting: noHighlighting
 							}"/>
 					</f:if>
 				</f:for>

--- a/Resources/Private/Plugins/Find/Templates/Search/Index.html
+++ b/Resources/Private/Plugins/Find/Templates/Search/Index.html
@@ -64,7 +64,7 @@
 						<li>
 							<f:if condition="{groupDisplayDocuments.{group.value}}">
 								<f:then>
-									<f:render partial="Display/Result" arguments="{document: '{groupDisplayDocuments.{group.value}}', config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments}"/>
+									<f:render partial="Display/Result" arguments="{document: '{groupDisplayDocuments.{group.value}}', config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments, noHighlighting: '1'}"/>
 								</f:then>
 								<f:else>
 									<f:render partial="Display/Result" arguments="{document: '{allDocuments.{group.value}}', config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments}"/>


### PR DESCRIPTION
This pull request introduces a new feature to optionally disable field highlighting in the display of search results. The main change is the addition and propagation of a `noHighlighting` parameter, which allows certain fields to be rendered without highlight markup. This provides more flexibility in how search results are displayed, especially for grouped documents and avoids running into exceptions when a doc is not inside the result set but enriched.