### PR TITLE
[BUGFIX] Remove document ID display from results

### DIFF
--- a/Resources/Private/Plugins/Find/Partials/Display/Result.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Result.html
@@ -43,9 +43,6 @@
 							noHighlighting: noHighlighting
 						}"/>
 				</f:then>
-				<f:else>
-					ID: {document.id}
-				</f:else>
 			</f:if>
 
 			<f:if condition="{settings.standardFields}">


### PR DESCRIPTION
Removes the fallback display of the raw document ID that appeared when no highlighting configuration was set.