### PR TITLE
Fix duplicate documents in grouped results and normalize groups

### DIFF
--- a/Classes/Service/GroupedSolrServiceProvider.php
+++ b/Classes/Service/GroupedSolrServiceProvider.php
@@ -487,6 +487,11 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
 
             // Resolve display documents for each group in batch to avoid N+1 Solr queries in Fluid templates.
             $result['groupDisplayDocuments'] = $this->resolveDisplayDocumentsForGroups($groupedResults, $allDocuments);
+            $result['groupedResults'] = $this->filterDocumentsDuplicatingGroupDisplay(
+                $groupedResults,
+                $result['groupDisplayDocuments'],
+                $allDocuments
+            );
             
             $this->localLogger->debug('Grouped results processed', [
                 'totalGroups' => $totalGroups,
@@ -796,6 +801,65 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
         }
 
         return $displayDocuments;
+    }
+
+    /**
+     * Removes subgroup documents that would render identically to the visible group header.
+     *
+     * @param array $groupedResults Template-friendly grouped result structure
+     * @param array $groupDisplayDocuments Display documents keyed by group value
+     * @param array $allDocuments Flat array of all documents keyed by group value
+     * @return array Grouped results with duplicate subgroup documents removed
+     */
+    protected function filterDocumentsDuplicatingGroupDisplay(
+        array $groupedResults,
+        array $groupDisplayDocuments,
+        array $allDocuments
+    ): array {
+        if (empty($groupedResults['valueGroups']) || !is_array($groupedResults['valueGroups'])) {
+            return $groupedResults;
+        }
+
+        foreach ($groupedResults['valueGroups'] as $index => $group) {
+            $groupValue = (string)($group['value'] ?? '');
+            $displayDocument = $groupDisplayDocuments[$groupValue] ?? $allDocuments[$groupValue] ?? null;
+            $displayDocumentId = $this->extractDocumentIdentifier($displayDocument);
+
+            if ($displayDocumentId === null || empty($group['documents']) || !is_array($group['documents'])) {
+                continue;
+            }
+
+            $groupedResults['valueGroups'][$index]['documents'] = array_values(array_filter(
+                $group['documents'],
+                function ($document) use ($displayDocumentId) {
+                    return $this->extractDocumentIdentifier($document) !== $displayDocumentId;
+                }
+            ));
+            $groupedResults['valueGroups'][$index]['numFound'] = count($groupedResults['valueGroups'][$index]['documents']);
+        }
+
+        return $groupedResults;
+    }
+
+    /**
+     * Extracts a stable identifier from a Solr document.
+     *
+     * @param mixed $document Solr document or array-like representation
+     * @return string|null
+     */
+    protected function extractDocumentIdentifier($document): ?string
+    {
+        if (!is_array($document) && !($document instanceof \ArrayAccess)) {
+            return null;
+        }
+
+        foreach (['id', 'uid'] as $field) {
+            if (!empty($document[$field])) {
+                return (string)$document[$field];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Service/GroupedSolrServiceProvider.php
+++ b/Classes/Service/GroupedSolrServiceProvider.php
@@ -487,8 +487,13 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
 
             // Resolve display documents for each group in batch to avoid N+1 Solr queries in Fluid templates.
             $result['groupDisplayDocuments'] = $this->resolveDisplayDocumentsForGroups($groupedResults, $allDocuments);
-            $result['groupedResults'] = $this->filterDocumentsDuplicatingGroupDisplay(
+            [$result['groupedResults'], $result['groupDisplayDocuments']] = $this->normalizeSingleParentGroups(
                 $groupedResults,
+                $result['groupDisplayDocuments'],
+                $allDocuments
+            );
+            $result['groupedResults'] = $this->filterDocumentsDuplicatingGroupDisplay(
+                $result['groupedResults'],
                 $result['groupDisplayDocuments'],
                 $allDocuments
             );
@@ -842,6 +847,65 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
     }
 
     /**
+     * Promotes a single matching parent document to the visible group header and fills
+     * the subgroup list with all documents that reference this parent via partof.
+     *
+     * @param array $groupedResults Template-friendly grouped result structure
+     * @param array $groupDisplayDocuments Display documents keyed by group value
+     * @param array $allDocuments Flat array of all documents keyed by group value
+     * @return array{0: array, 1: array} Updated grouped results and display documents
+     */
+    protected function normalizeSingleParentGroups(
+        array $groupedResults,
+        array $groupDisplayDocuments,
+        array $allDocuments
+    ): array {
+        if (empty($groupedResults['valueGroups']) || !is_array($groupedResults['valueGroups'])) {
+            return [$groupedResults, $groupDisplayDocuments];
+        }
+
+        $parentUidsByGroupIndex = [];
+        foreach ($groupedResults['valueGroups'] as $index => $group) {
+            $documents = $group['documents'] ?? [];
+            if (!is_array($documents) || count($documents) !== 1) {
+                continue;
+            }
+
+            $parentUid = $this->extractDocumentUid($documents[0]);
+            if ($parentUid === null) {
+                continue;
+            }
+
+            $parentUidsByGroupIndex[$index] = $parentUid;
+        }
+
+        if (empty($parentUidsByGroupIndex)) {
+            return [$groupedResults, $groupDisplayDocuments];
+        }
+
+        $childDocumentsByParentUid = $this->fetchDocumentsByPartOfUids(array_values($parentUidsByGroupIndex));
+
+        foreach ($parentUidsByGroupIndex as $index => $parentUid) {
+            $childDocuments = $childDocumentsByParentUid[$parentUid] ?? [];
+            if (empty($childDocuments)) {
+                continue;
+            }
+
+            $groupValue = (string)($groupedResults['valueGroups'][$index]['value'] ?? '');
+            $parentDocument = $groupedResults['valueGroups'][$index]['documents'][0] ?? null;
+            if ($groupValue === '' || $parentDocument === null) {
+                continue;
+            }
+
+            $groupDisplayDocuments[$groupValue] = $parentDocument;
+            $groupedResults['valueGroups'][$index]['documents'] = array_values($childDocuments);
+            $groupedResults['valueGroups'][$index]['numFound'] = count($childDocuments);
+        }
+
+        return [$groupedResults, $groupDisplayDocuments];
+    }
+
+    /**
      * Extracts a stable identifier from a Solr document.
      *
      * @param mixed $document Solr document or array-like representation
@@ -857,6 +921,25 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
             if (!empty($document[$field])) {
                 return (string)$document[$field];
             }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts a document UID from a Solr document.
+     *
+     * @param mixed $document Solr document or array-like representation
+     * @return string|null
+     */
+    protected function extractDocumentUid($document): ?string
+    {
+        if (!is_array($document) && !($document instanceof \ArrayAccess)) {
+            return null;
+        }
+
+        if (!empty($document['uid'])) {
+            return (string)$document['uid'];
         }
 
         return null;
@@ -906,6 +989,58 @@ class GroupedSolrServiceProvider extends SolrServiceProvider
 
             return [];
         }
+    }
+
+    /**
+     * Fetches documents grouped by their partof reference.
+     *
+     * @param array $parentUids Parent UIDs to resolve child documents for
+     * @return array<string, array> Documents keyed by parent UID
+     */
+    protected function fetchDocumentsByPartOfUids(array $parentUids): array
+    {
+        $parentUids = array_values(array_unique(array_filter(array_map('strval', $parentUids), static function ($uid) {
+            return $uid !== '';
+        })));
+
+        if (empty($parentUids)) {
+            return [];
+        }
+
+        $query = implode(' OR ', array_map(static function ($uid) {
+            return 'partof:' . $uid;
+        }, $parentUids));
+
+        try {
+            $selectQuery = $this->connection->createSelect();
+            $selectQuery->setQuery($query);
+
+            /** @var \Solarium\QueryType\Select\Result\Result $result */
+            $result = $this->connection->execute($selectQuery);
+
+            $documentsByParentUid = [];
+            foreach ($result as $document) {
+                if (empty($document['partof'])) {
+                    continue;
+                }
+
+                $parentUid = (string)$document['partof'];
+                if (!isset($documentsByParentUid[$parentUid])) {
+                    $documentsByParentUid[$parentUid] = [];
+                }
+
+                $documentsByParentUid[$parentUid][] = $document;
+            }
+
+            return $documentsByParentUid;
+        } catch (\Exception $e) {
+            $this->localLogger->error('Error fetching child documents by parent UID', [
+                'exception' => $e->getMessage(),
+                'parentUidCount' => count($parentUids)
+            ]);
+        }
+
+        return [];
     }
 
     /**

--- a/Classes/ViewHelpers/XpathViewHelper.php
+++ b/Classes/ViewHelpers/XpathViewHelper.php
@@ -186,9 +186,9 @@ class XpathViewHelper extends AbstractViewHelper
      *
      * @static
      *
-     * @return DocumentRepository|null
+     * @return DocumentRepository
      */
-    private static function getDocumentRepository(): ?DocumentRepository
+    private static function getDocumentRepository(): DocumentRepository
     {
         if (self::$documentRepository === null) {
             self::$documentRepository = GeneralUtility::makeInstance(DocumentRepository::class);

--- a/Resources/Private/Plugins/Find/Partials/Display/Field/General.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Field/General.html
@@ -1,4 +1,5 @@
 {namespace s=Subugoe\Find\ViewHelpers}
+{namespace slub=Slub\SlubDigitalcollections\ViewHelpers}
 <f:comment>
 	Creates output for field contents.
 	Takes into account whether the field is an array and inserts the prefixes
@@ -52,7 +53,7 @@
 													<f:translate key="find.display.type.{value}" extensionName="slub_digitalcollections" default="{value}" />
 												</f:then>
 												<f:else>
-													<s:find.highlightField
+													<slub:find.highlightField
 														field="{field}"
 														document="{document}"
 														results="{results}"
@@ -98,7 +99,7 @@
 												<f:translate key="find.display.type.{value}" extensionName="slub_digitalcollections" default="{value}" />
 											</f:then>
 											<f:else>
-												<s:find.highlightField
+													<slub:find.highlightField
 													field="{field}"
 													document="{document}"
 													results="{results}"
@@ -141,7 +142,7 @@
 									<f:translate key="find.display.type.{document.fields.{field}}" extensionName="slub_digitalcollections" default="{document.fields.{field}}" />
 								</f:then>
 								<f:else>
-									<s:find.highlightField
+									<slub:find.highlightField
 										field="{field}"
 										document="{document}"
 										results="{results}"

--- a/Resources/Private/Plugins/Find/Partials/Display/Result.html
+++ b/Resources/Private/Plugins/Find/Partials/Display/Result.html
@@ -62,6 +62,7 @@
 					</f:if>
 				</f:for>
 			</f:if>
+			<!-- ID: {document.uid} -->
 		</dl>
 
 	</f:link.page>

--- a/Resources/Private/Plugins/Find/Templates/Search/Index.html
+++ b/Resources/Private/Plugins/Find/Templates/Search/Index.html
@@ -68,25 +68,27 @@
 									<f:render partial="Display/Result" arguments="{document: '{allDocuments.{group.value}}', config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments}"/>
 								</f:else>
 							</f:if>
-							<button
-								type="button"
-								class="tx-dlf-morevolumes"
-								title="{f:translate(key: 'find.list.more', extensionName: 'slub_digitalcollections')}"
-								aria-expanded="false"
-								aria-controls="volume-list-{config.uid}-{groupIterator.cycle}">{f:translate(key: 'find.list.more', extensionName: 'slub_digitalcollections')}</button>
+							<f:if condition="{group.documents}">
+								<button
+									type="button"
+									class="tx-dlf-morevolumes"
+									title="{f:translate(key: 'find.list.more', extensionName: 'slub_digitalcollections')}"
+									aria-expanded="false"
+									aria-controls="volume-list-{config.uid}-{groupIterator.cycle}">{f:translate(key: 'find.list.more', extensionName: 'slub_digitalcollections')}</button>
 
-							<ol class="tx-dlf-volume" id="volume-list-{config.uid}-{groupIterator.cycle}" aria-hidden="true">
-								<f:for each="{group.documents}" as="subDocument">
-									<li class="pageresult">
-										<f:render partial="Display/Result" arguments="{document: subDocument, config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments}"/>
-										<f:if condition="{arguments.searchMode} == 'fulltext'">
-											<f:for each="{results.data.highlighting.{subDocument.id}}" as="highlight">
-												<p><i><f:format.raw>{highlight.0 -> f:replace(search: '\ueeee', replace: '<strong>') -> f:replace(search: '\ueeef', replace: '</strong>') -> f:replace(search: '<b>', replace: '') -> f:replace(search: '</b>', replace: '')}</f:format.raw></i></p>
-											</f:for>
-										</f:if>
-									</li>
-								</f:for>
-							</ol>
+								<ol class="tx-dlf-volume" id="volume-list-{config.uid}-{groupIterator.cycle}" aria-hidden="true">
+									<f:for each="{group.documents}" as="subDocument">
+										<li class="pageresult">
+											<f:render partial="Display/Result" arguments="{document: subDocument, config: config, settings: settings, results: results, additionalTitleInfo: additionalTitleInfo, arguments: arguments}"/>
+											<f:if condition="{arguments.searchMode} == 'fulltext'">
+												<f:for each="{results.data.highlighting.{subDocument.id}}" as="highlight">
+													<p><i><f:format.raw>{highlight.0 -> f:replace(search: '\ueeee', replace: '<strong>') -> f:replace(search: '\ueeef', replace: '</strong>') -> f:replace(search: '<b>', replace: '') -> f:replace(search: '</b>', replace: '')}</f:format.raw></i></p>
+												</f:for>
+											</f:if>
+										</li>
+									</f:for>
+								</ol>
+							</f:if>
 						</li>
 
 					</f:for>


### PR DESCRIPTION
This pull request introduces several improvements to the grouping and display logic for Solr search results, focusing on de-duplication, normalization of parent/child document groups, and template rendering enhancements. The main service (`GroupedSolrServiceProvider.php`) now ensures that group headers and subgroup lists are rendered without redundant or duplicate documents, and new helper methods have been added to support these features. Additionally, template files have been updated to use the correct ViewHelper and improve conditional rendering.
