### PR TITLE
[MAINTENANCE] Refactor calendar view identification

### DIFF
--- a/Configuration/TypoScript/Plugin/Kitodo/Workview/setup.typoscript
+++ b/Configuration/TypoScript/Plugin/Kitodo/Workview/setup.typoscript
@@ -708,15 +708,19 @@ lib.kitodo.newspaper.calendar {
 
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) === 'ephemera' or getDocumentType({$plugin.tx_dlf.persistence.storagePid}) === 'newspaper']
 page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_anchor
+    isCalendar = TEXT
+    isCalendar.value = 1
+    isCalendarType = TEXT
+    isCalendarType.value = anchor
 }
 [END]
 
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) === 'year']
 page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_year
+    isCalendar = TEXT
+    isCalendar.value = 1
+    isCalendarType = TEXT
+    isCalendarType.value = year
 }
 # in year files, the full year is only in mets_orderlabel - not year field in Kitodo.Presentation 3.0
 page.2 {
@@ -741,10 +745,6 @@ page.2.postTitle.cObject {
 [END]
 
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) === 'issue']
-page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_issue
-}
 # The issue has YYYY-MM-DD as dateformat for the publishing date. We can format it in a localized format:
 page.2.postTitle.cObject {
     30 = TEXT

--- a/Resources/Private/Partials/KitodoDocumentFunctions.html
+++ b/Resources/Private/Partials/KitodoDocumentFunctions.html
@@ -20,7 +20,7 @@
 
 <div class="document-functions">
     <f:render partial="Kitodo/DocumentFunctions/Provider" arguments="{_all}" />
-    <f:if condition="{isNewspaper} == 'newspaper_anchor' OR {isNewspaper} == 'newspaper_year'">
+    <f:if condition="{isCalendar} == 1">
         <f:else>
             <f:render partial="Kitodo/DocumentFunctions/Submenu" arguments="{_all}"/>
         </f:else>

--- a/Resources/Private/Partials/KitodoNewspaper.html
+++ b/Resources/Private/Partials/KitodoNewspaper.html
@@ -14,7 +14,7 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:if condition="{isNewspaper} == 'newspaper_anchor'">
+<f:if condition="{isCalendarType} == 'anchor'">
     <f:then>
         <f:cObject typoscriptObjectPath="lib.kitodo.newspaper.years" />
         <f:if condition="{gp-id} > 0">
@@ -23,7 +23,7 @@
         </f:if>
     </f:then>
     <f:else>
-        <f:if condition="{isNewspaper} == 'newspaper_year'">
+        <f:if condition="{isCalendarType} == 'year'">
             <f:cObject typoscriptObjectPath="lib.kitodo.newspaper.calendar" />
             <f:if condition="{gp-id} > 0">
                 <!-- gp-id must be integer otherwise the search in document won't work -->

--- a/Resources/Private/Templates/Kitodo.html
+++ b/Resources/Private/Templates/Kitodo.html
@@ -26,7 +26,7 @@
         <f:then>
             <f:render section="MediaView" partial="KitodoMediaView" arguments="{_all}" />
         </f:then>
-        <f:else if="{isNewspaper} == 'newspaper_anchor' OR {isNewspaper} == 'newspaper_year'">
+        <f:else if="{isCalendar} == 1">
             <f:render section="CalendarView" partial="KitodoCalendarView" arguments="{_all}" />
         </f:else>
         <f:else if="{isMultivolumeWork} == 1">


### PR DESCRIPTION
Replaces the overloaded `isNewspaper` variable with explicit `isCalendar` and `isCalendarType` variables. This clarifies the logic for rendering different calendar views in TypoScript and Fluid templates, making the conditions more readable and maintainable.